### PR TITLE
add lower() for real_match() in class Manchu_VDict

### DIFF
--- a/lingollm/vdict.py
+++ b/lingollm/vdict.py
@@ -65,7 +65,8 @@ class Manchu_VDict(VDict):
         time.sleep(self.wait_time)
         
         word_form = self.driver.find_element(By.XPATH, '//*[@id="root"]/div/header/div/div/div/div/h6').text
-        if not key.startswith(word_form) and not word_form.startswith(key):
+        #if not key.startswith(word_form) and not word_form.startswith(key):
+        if not key.lower().startswith(word_form.lower()) and not word_form.lower().startswith(key.lower()):
             return None
         
         first_result = self.driver.find_element(By.XPATH, '//*[@id="root"]/div/div[1]/div/div/div/div[1]/div/div/ul/li[1]/div')


### PR DESCRIPTION
Currently real_match() of class Manchu_VDict will return None for words like 'abkai wehiyehe', 'Solho', and 'solho hooxan' (whose parent is 'Solho' in the dictionary).

To solve this, .lower() is added